### PR TITLE
Connect to mariadb

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -8,5 +8,12 @@
       <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/icbot.sqlite</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="mariadb@aws" uuid="c8cf3984-05e4-43b7-a15c-3d1d549447b5">
+      <driver-ref>mariadb</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.mariadb.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mariadb://database-infochallenge.ce6lmfkwtjyf.us-east-1.rds.amazonaws.com:3306/infochallengebot</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,6 @@ RUN mkdir data
 
 COPY /src .
 COPY .env ./
-#CMD tail -f /dev/null
 
 ENTRYPOINT ./docker-entrypoint.sh $0 $@
 CMD ["python", "bot.py"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -131,6 +131,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "mariadb"
+version = "1.0.9"
+description = "Python MariaDB extension"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "multidict"
 version = "5.2.0"
 description = "multidict implementation"
@@ -261,7 +269,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "456cb18d9167659071e4141c57f7b68bb8e683b6334e69841cc01471afd016a4"
+content-hash = "d39cdf7ae76dbc8fab85174c83e0e67ad7484d0ed39e6045087eb19c264b51ac"
 
 [metadata.files]
 aiodns = [
@@ -623,6 +631,19 @@ greenlet = [
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+mariadb = [
+    {file = "mariadb-1.0.9-cp310-cp310-win32.whl", hash = "sha256:230fcd896d2d4fc0f67838d40264e18da434463b5865bbe236d0bbbf765aa8f3"},
+    {file = "mariadb-1.0.9-cp310-cp310-win_amd64.whl", hash = "sha256:80d794af99c452f228590a5a2296a61688090cbd1f6c5b129069619f13f4ca50"},
+    {file = "mariadb-1.0.9-cp36-cp36m-win32.whl", hash = "sha256:c2206727a01d261d3bcf7aaf268d7ee085442e11f0e2aee025e4bffb36bf1fc8"},
+    {file = "mariadb-1.0.9-cp36-cp36m-win_amd64.whl", hash = "sha256:94bb549b4feb89202cff7218680b4e997f0181600534b39948d8ccb2fa21e136"},
+    {file = "mariadb-1.0.9-cp37-cp37m-win32.whl", hash = "sha256:63be7d5f2a8f84dd10f6be171ce4a2bf1591e22da7b081fb1a76d1f26c873302"},
+    {file = "mariadb-1.0.9-cp37-cp37m-win_amd64.whl", hash = "sha256:cd91814c836a2b544060a2e892d151f0ea63ac6fb8b4535db563b7cb8275537e"},
+    {file = "mariadb-1.0.9-cp38-cp38-win32.whl", hash = "sha256:3f251e324a699b72a79762353579da3130a2daf263d7734af1b57450517a7f5a"},
+    {file = "mariadb-1.0.9-cp38-cp38-win_amd64.whl", hash = "sha256:6855beef3944096a393a6b35d5a8fdf2d83aabd918b531063ec95ade68824544"},
+    {file = "mariadb-1.0.9-cp39-cp39-win32.whl", hash = "sha256:bc71899680bb9de9a138e1efae24efaf7fcc45033b77df64e772915d7f912bab"},
+    {file = "mariadb-1.0.9-cp39-cp39-win_amd64.whl", hash = "sha256:dd5d46a0af63ed2dc0b417252c6437362b5fe2c8bd694d2195be795440f92cf5"},
+    {file = "mariadb-1.0.9.zip", hash = "sha256:02a9b3d0a076e9a0d0ea1c48b45ed09b6475e2b6a4e8c81ed9f1e82caf3bfc29"},
 ]
 multidict = [
     {file = "multidict-5.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3822c5894c72e3b35aae9909bef66ec83e44522faf767c0ad39e0e2de11d3b55"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python-dotenv = "^0.19.2"
 validate-email-address = "^1"
 SQLAlchemy = "^1.4.29"
 py-cord = { git = "https://github.com/Pycord-Development/pycord.git", rev = "8ed1a43", extras = ["speed"]}
+mariadb = "^1.0.9"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -3,6 +3,8 @@ import os
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Integer
+from sqlalchemy.dialects.mysql import BIGINT
 
 from dotenv import load_dotenv
 
@@ -13,6 +15,11 @@ DB_CONN_URI = os.environ['db_conn_uri']
 engine = create_engine(DB_CONN_URI)
 Session = sessionmaker(bind=engine)
 Base = declarative_base()
+
+# Make an UnsignedInt that is compat with both sqlite and MariaDB
+UnsignedInt = Integer()
+UnsignedInt = UnsignedInt.with_variant(BIGINT(unsigned=True), 'mysql')
+UnsignedInt = UnsignedInt.with_variant(BIGINT(unsigned=True), 'mariadb')
 
 __all__ = ['Session', 'Registration', 'ConvoState', 'Participant', 'init_db']
 

--- a/src/models/convostate.py
+++ b/src/models/convostate.py
@@ -1,16 +1,16 @@
 from sqlalchemy import Column, Integer, String
-from . import Base
+from . import Base, UnsignedInt
 
 
 class ConvoState(Base):
     __tablename__ = 'convo_state'
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    discord_id = Column(Integer, nullable=False)
-    guild_id = Column(Integer, nullable=False)
-    conversation = Column(String, nullable=False)
-    state = Column(String, nullable=False)
-    email = Column(String)
+    discord_id = Column(UnsignedInt, nullable=False)
+    guild_id = Column(UnsignedInt, nullable=False)
+    conversation = Column(String(255), nullable=False)
+    state = Column(String(255), nullable=False)
+    email = Column(String(255))
 
     def __repr__(self):
         return f"<ConvoStep(guild_id={self.guild_id}, discord_id={self.discord_id}, "\

--- a/src/models/participant.py
+++ b/src/models/participant.py
@@ -1,13 +1,13 @@
 from sqlalchemy import Column, Integer, String
-from . import Base
+from . import Base, UnsignedInt
 
 
 class Participant(Base):
     __tablename__ = 'participants'
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    discord_id = Column(Integer, nullable=False)
-    guild_id = Column(Integer, nullable=False)
+    discord_id = Column(UnsignedInt, nullable=False)
+    guild_id = Column(UnsignedInt, nullable=False)
     email = Column(String(255), nullable=False)
     institution = Column(String(255), nullable=False)
     role = Column(String(255), default='Participant')

--- a/src/models/registration.py
+++ b/src/models/registration.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String
-from . import Base
+from . import Base, UnsignedInt
 
 from dotenv import load_dotenv
 import os
@@ -49,7 +49,7 @@ class Registration(Base):
     __tablename__ = 'registrations'
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    guild_id = Column(Integer, nullable=False)
+    guild_id = Column(UnsignedInt, nullable=False)
     full_name = Column(String(255), nullable=False)
     email = Column(String(255), nullable=False)
     institution = Column(String(255), nullable=False)


### PR DESCRIPTION
Initial development was with a local sqlite database, but production needs to use an external database to maintain state in case the container needs to be reloaded.

The Discord snowflake type is a 64-bit unsigned integer and while sqlite is unphased, sqlalchemy was not creating an Unsigned BigInt. This change will allow both to work.